### PR TITLE
Created Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,12 @@ LIBS += $(shell sdl2-config --libs)
 SOURCES = $(wildcard *.c)
 HEADERS = $(wildcard *.h)
 
+all: mercyboy
+
 mercyboy: $(SOURCES) $(HEADERS) Makefile
 	$(CC) $(CFLAGS) -o mercyboy $(SOURCES) $(LIBS)
+
+clean:
+	rm -f mercyboy
+
+.PHONY: all clean

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+CFLAGS = -Wall -Wextra -Os
+LIBS = -lm
+
+CFLAGS += -DVIDEO_SDL2 -DAUDIO_SDL2 -DINPUT_SDL2 $(shell sdl2-config --cflags)
+LIBS += $(shell sdl2-config --libs)
+
+SOURCES = $(wildcard *.c)
+HEADERS = $(wildcard *.h)
+
+mercyboy: $(SOURCES) $(HEADERS) Makefile
+	$(CC) $(CFLAGS) -o mercyboy $(SOURCES) $(LIBS)


### PR DESCRIPTION
This makes it easier to compile the project without having qmake installed.

It uses the SDL2 backends and finds the appropriate flags with the sdl2-confiig tool which is distributed as part of SDL2.