### PR TITLE
Change misleading indentation.

### DIFF
--- a/cpu_opcodes.c
+++ b/cpu_opcodes.c
@@ -824,13 +824,17 @@ void op_jp_cc(){
     uint16_t old_pc = *pc;
     switch (op_get_cc(op)) {
     case COND_NZ:
-        if (!(*flags & FLAG_Z)) *pc = cpu_read16(*pc+1); break;
+        if (!(*flags & FLAG_Z)) *pc = cpu_read16(*pc+1);
+        break;
     case COND_Z:
-        if (*flags & FLAG_Z) *pc = cpu_read16(*pc+1); break;
+        if (*flags & FLAG_Z) *pc = cpu_read16(*pc+1);
+        break;
     case COND_NC:
-        if (!(*flags & FLAG_C)) *pc = cpu_read16(*pc+1); break;
+        if (!(*flags & FLAG_C)) *pc = cpu_read16(*pc+1);
+        break;
     case COND_C:
-        if (*flags & FLAG_C) *pc = cpu_read16(*pc+1); break;
+        if (*flags & FLAG_C) *pc = cpu_read16(*pc+1);
+        break;
     }
 
     if (old_pc == *pc) ipc(3);
@@ -880,13 +884,17 @@ void op_call_cc(){
     uint16_t old_pc = *pc;
     switch (op_get_cc(op)) {
     case COND_NZ:
-        if (!(*flags & FLAG_Z)) *pc = cpu_read16(*pc+1); break;
+        if (!(*flags & FLAG_Z)) *pc = cpu_read16(*pc+1);
+        break;
     case COND_Z:
-        if (*flags & FLAG_Z) *pc = cpu_read16(*pc+1); break;
+        if (*flags & FLAG_Z) *pc = cpu_read16(*pc+1);
+        break;
     case COND_NC:
-        if (!(*flags & FLAG_C)) *pc = cpu_read16(*pc+1); break;
+        if (!(*flags & FLAG_C)) *pc = cpu_read16(*pc+1);
+        break;
     case COND_C:
-        if (*flags & FLAG_C) *pc = cpu_read16(*pc+1); break;
+        if (*flags & FLAG_C) *pc = cpu_read16(*pc+1);
+        break;
     }
 
     if (old_pc == *pc) {
@@ -918,13 +926,17 @@ void op_ret_cc() {
     uint16_t old_pc = *pc;
     switch (op_get_cc(op)) {
     case COND_NZ:
-        if (!(*flags & FLAG_Z)) *pc = cpu_read16(bs(*sp)); break;
+        if (!(*flags & FLAG_Z)) *pc = cpu_read16(bs(*sp));
+        break;
     case COND_Z:
-        if (*flags & FLAG_Z) *pc = cpu_read16(bs(*sp)); break;
+        if (*flags & FLAG_Z) *pc = cpu_read16(bs(*sp));
+        break;
     case COND_NC:
-        if (!(*flags & FLAG_C)) *pc = cpu_read16(bs(*sp)); break;
+        if (!(*flags & FLAG_C)) *pc = cpu_read16(bs(*sp));
+        break;
     case COND_C:
-        if (*flags & FLAG_C) *pc = cpu_read16(bs(*sp)); break;
+        if (*flags & FLAG_C) *pc = cpu_read16(bs(*sp));
+        break;
     }
 
     if (old_pc == *pc) {


### PR DESCRIPTION
Since the break statements follow on the same lines as the if statements, gcc complains about misleading indentation because the break is executed whether the if is executed or not.
By moving the break to the next line this gets clearer and gcc is happy.