### PR TITLE
Makefile overhaul.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,94 @@
+# Configuration
+# Select backends by setting the variables BACKEND_VIDEO, BACKEND_AUDIO and BACKEND_INPUT.
+# Select timing options by setting the variable TIMING.
+# Possible values:
+# BACKEND_VIDEO: sdl (default), gdi
+# BACKEND_AUDIO: sdl (default)
+# BACKEND_INPUT: sdl (default), win32
+# TIMING: audio (default), delay
+
+# Handle default values
+ifeq ($(BACKEND_VIDEO),)
+	BACKEND_VIDEO = sdl
+endif
+ifeq ($(BACKEND_AUDIO),)
+	BACKEND_AUDIO = sdl
+endif
+ifeq ($(BACKEND_INPUT),)
+	BACKEND_INPUT = sdl
+endif
+ifeq ($(TIMING),)
+	TIMING = audio
+endif
+
+# Remember which libraries need to be linked.
+NEED_SDL = no
+NEED_GDI = no
+NEED_WIN32 = no
+
 CFLAGS = -Wall -Wextra -Os
 LIBS = -lm
 
-CFLAGS_SDL2 = -DVIDEO_SDL2 -DAUDIO_SDL2 -DINPUT_SDL2 -DUSE_AUDIO_TIMING
+# Video backend
+ifeq ($(BACKEND_VIDEO),sdl)
+	CFLAGS += -DVIDEO_SDL2
+	NEED_SDL = yes
+endif
+ifeq ($(BACKEND_VIDEO),gdi)
+	CFLAGS += -DVIDEO_GDI
+	NEED_GDI = yes
+endif
+
+# Audio backend
+ifeq ($(BACKEND_AUDIO),sdl)
+	CFLAGS += -DAUDIO_SDL2
+	NEED_SDL = yes
+endif
+
+# Input backend
+ifeq ($(BACKEND_INPUT),sdl)
+	CFLAGS += -DINPUT_SDL2
+	NEED_SDL = yes
+endif
+ifeq ($(BACKEND_INPUT),win32)
+	CFLAGS += -DINPUT_WIN32
+	NEED_WIN32 = yes
+endif
+
+# Timing
+ifeq ($(TIMING),audio)
+	CFLAGS += -DUSE_AUDIO_TIMING
+endif
 
 # Building with an older version of MINGW32
 ifeq ($(MAKE),mingw32-make)
 	CC = gcc
 endif
 
+ifeq ($(NEED_SDL),yes)
+	ifeq ($(OS),Windows_NT)
+		LIBS += -lmingw32 -lSDL2main -lSDL2
+	else
+		CFLAGS += $(shell sdl2-config --cflags)
+		LIBS += $(shell sdl2-config --libs)
+	endif
+endif
+ifeq ($(NEED_GDI),yes)
+	# TODO
+endif
+ifeq ($(NEED_WIN32),yes)
+	# TODO
+endif
+
+# Set executable name
 ifeq ($(OS),Windows_NT)
 	EXECUTABLE = mercyboy.exe
-	LIBS_SDL2 = -lSDL2main -lSDL2
-	LIBS += -lmingw32
 else
 	EXECUTABLE = mercyboy
-	CFLAGS_SDL2 = $(shell sdl2-config --cflags)
-	LIBS_SDL2 = $(shell sdl2-config --libs)
 endif
 
 SOURCES = $(wildcard *.c)
 HEADERS = $(wildcard *.h)
-
-CFLAGS += $(CFLAGS_SDL2)
-LIBS += $(LIBS_SDL2)
 
 all: $(EXECUTABLE)
 

--- a/Makefile
+++ b/Makefile
@@ -2,27 +2,27 @@
 # Select backends by setting the variables BACKEND_VIDEO, BACKEND_AUDIO and BACKEND_INPUT.
 # Select timing options by setting the variable TIMING.
 # Possible values:
-# BACKEND_VIDEO: sdl (default), gdi
-# BACKEND_AUDIO: sdl (default)
-# BACKEND_INPUT: sdl (default), win32
+# BACKEND_VIDEO: sdl2 (default), gdi
+# BACKEND_AUDIO: sdl2 (default)
+# BACKEND_INPUT: sdl2 (default), win32
 # TIMING: audio (default), delay
 
 # Handle default values
 ifeq ($(BACKEND_VIDEO),)
-	BACKEND_VIDEO = sdl
+	BACKEND_VIDEO = sdl2
 endif
 ifeq ($(BACKEND_AUDIO),)
-	BACKEND_AUDIO = sdl
+	BACKEND_AUDIO = sdl2
 endif
 ifeq ($(BACKEND_INPUT),)
-	BACKEND_INPUT = sdl
+	BACKEND_INPUT = sdl2
 endif
 ifeq ($(TIMING),)
 	TIMING = audio
 endif
 
 # Remember which libraries need to be linked.
-NEED_SDL = no
+NEED_SDL2 = no
 NEED_GDI = no
 NEED_WIN32 = no
 
@@ -30,9 +30,9 @@ CFLAGS = -Wall -Wextra -Os
 LIBS = -lm
 
 # Video backend
-ifeq ($(BACKEND_VIDEO),sdl)
+ifeq ($(BACKEND_VIDEO),sdl2)
 	CFLAGS += -DVIDEO_SDL2
-	NEED_SDL = yes
+	NEED_SDL2 = yes
 endif
 ifeq ($(BACKEND_VIDEO),gdi)
 	CFLAGS += -DVIDEO_GDI
@@ -40,15 +40,15 @@ ifeq ($(BACKEND_VIDEO),gdi)
 endif
 
 # Audio backend
-ifeq ($(BACKEND_AUDIO),sdl)
+ifeq ($(BACKEND_AUDIO),sdl2)
 	CFLAGS += -DAUDIO_SDL2
-	NEED_SDL = yes
+	NEED_SDL2 = yes
 endif
 
 # Input backend
-ifeq ($(BACKEND_INPUT),sdl)
+ifeq ($(BACKEND_INPUT),sdl2)
 	CFLAGS += -DINPUT_SDL2
-	NEED_SDL = yes
+	NEED_SDL2 = yes
 endif
 ifeq ($(BACKEND_INPUT),win32)
 	CFLAGS += -DINPUT_WIN32
@@ -65,7 +65,7 @@ ifeq ($(MAKE),mingw32-make)
 	CC = gcc
 endif
 
-ifeq ($(NEED_SDL),yes)
+ifeq ($(NEED_SDL2),yes)
 	ifeq ($(OS),Windows_NT)
 		LIBS += -lmingw32 -lSDL2main -lSDL2
 	else


### PR DESCRIPTION
The makefile can now select different backend options depending on set variables.

For example to build with the GDI backend:

    make BACKEND_VIDEO=gdi

This still needs work when building with a non-SDL backend.